### PR TITLE
Slight modifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yum --setopt=tsflags=nodocs -y install nfs-utils
 #RUN wget http://download.gluster.org/pub/gluster/glusterfs/3.5/LATEST/CentOS/glusterfs-epel.repo -O /etc/yum.repos.d/glusterfs-epel.repo
 
 RUN yum --setopt=tsflags=nodocs -y install glusterfs glusterfs-server glusterfs-fuse glusterfs-geo-replication glusterfs-cli glusterfs-api
-RUN yum --setopt=tsflags=nodocs -y install attr supervisor
+RUN yum --setopt=tsflags=nodocs -y install attr supervisor systemd
 RUN yum clean all
 
 #ADD start-gluster.sh /
@@ -19,9 +19,14 @@ RUN yum clean all
 
 
 RUN mkdir -p /var/log/supervisor
+RUN mkdir -p /var/run/sshd
+RUN echo 'root:password' | chpasswd
+RUN ssh-keygen -A
+VOLUME [ “/sys/fs/cgroup” ]
+
 ADD makefusedev.sh /usr/sbin/makefusedev.sh
 ADD supervisord.conf /etc/supervisord.conf
 
 EXPOSE 22 111 245 443 24007 2049 8080 6010 6011 6012 38465 38466 38468 38469 49152 49153 49154 49156 49157 49158 49159 49160 49161 49162
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,8 +1,8 @@
 [supervisord]
 nodaemon=true
 
-[program:glusterd]
-command=service glusterd start
+[program:sshd]
+command=/usr/sbin/sshd -D
 autorestart=true
 
 [program:rpcbind]


### PR DESCRIPTION
Creating user root for ssh-ing, specifying the config file and removing glusterd start. Glusterd will not get started even in this way. It's not the kind of program supervisor is designed to manage.

Programs meant to be run under supervisor should not daemonize themselves. Instead, they should run in the foreground. They should not detach from the terminal from which they are started.
After the docker image is ran, one can get the IP of the container and
ssh to it. glusterd should be manually started there.
